### PR TITLE
Support for Preact 8! 🎉

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "webpack-dev-server": "^1.14.1"
   },
   "dependencies": {
-    "preact": "^4.8.0",
-    "preact-redux": "^1.0.1",
-    "redux": "^3.5.2"
+    "preact": "^8.1.0",
+    "preact-redux": "^1.2.0",
+    "redux": "^3.6.0"
   }
 }

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -8,9 +8,8 @@ import TodoItem from './todo-item';
 @connect(reduce, bindActions(actions))
 export default class App extends Component {
 	addTodos = () => {
-		let { text } = this.state;
-		this.setState({ text: '' });
-		this.props.addTodo(text);
+		this.props.addTodo(this.input.value);
+		this.input.value = '';
 		return false;
 	};
 
@@ -22,7 +21,7 @@ export default class App extends Component {
 		return (
 			<div id="app">
 				<form onSubmit={this.addTodos} action="javascript:">
-					<input value={text} onInput={this.linkState('text')} placeholder="New ToDo..." />
+					<input value={text} ref={(input) => { this.input = input; }} placeholder="New ToDo..." />
 				</form>
 				<ul>
 					{ todos.map(todo => (

--- a/src/components/app.js
+++ b/src/components/app.js
@@ -8,8 +8,9 @@ import TodoItem from './todo-item';
 @connect(reduce, bindActions(actions))
 export default class App extends Component {
 	addTodos = () => {
-		this.props.addTodo(this.input.value);
-		this.input.value = '';
+		const { text } = this.state;
+		this.setState({ text: '' });
+		this.props.addTodo(text);
 		return false;
 	};
 
@@ -17,11 +18,15 @@ export default class App extends Component {
 		this.props.removeTodo(todo);
 	};
 
+	updateText = (e) => {
+		this.setState({ text: e.target.value });
+	};
+
 	render({ todos }, { text }) {
 		return (
 			<div id="app">
 				<form onSubmit={this.addTodos} action="javascript:">
-					<input value={text} ref={(input) => { this.input = input; }} placeholder="New ToDo..." />
+					<input value={text} onInput={this.updateText} placeholder="New ToDo..." />
 				</form>
 				<ul>
 					{ todos.map(todo => (


### PR DESCRIPTION
**Dependencies updated:**

- Preact: v4.8.0 -> v8.1.0
- Preact-redux: v1.0.1 -> v1.2.0
- Redux: v3.5.2 -> v3.6.0

Due to `linkState()` being removed from Preact 8 the demo was updated to use the input as a reference and store it's value in the store.